### PR TITLE
Fix `data-` prefix duplication

### DIFF
--- a/macros/src/html.rs
+++ b/macros/src/html.rs
@@ -77,7 +77,7 @@ fn extract_data_attrs(attrs: &mut StringyMap<Ident, TokenTree>) -> StringyMap<St
         let prefix = "data_";
         if key_name.starts_with(prefix) {
             let value = attrs.remove(&key).unwrap();
-            data.insert(format!("data-{}", &key_name[prefix.len()..]), value);
+            data.insert(key_name[prefix.len()..].to_string(), value);
         }
     }
     data

--- a/typed-html/src/elements.rs
+++ b/typed-html/src/elements.rs
@@ -410,3 +410,13 @@ declare_elements!{
         width: String, // FIXME size
     } in [FlowContent, PhrasingContent] with PhrasingContent;
 }
+
+#[test]
+fn test_data_attributes() {
+    use crate as typed_html;
+    use crate::dom::DOMTree;
+
+    let frag: DOMTree<String> = html!(<div data-id="1234">"Boo!"</div>);
+
+    assert_eq!("<div data-id=\"1234\">Boo!</div>", frag.to_string());
+}


### PR DESCRIPTION
The `data-` prefix is being duplicated, such that `data-foo="bar"` is being rendered as `data-data-foo="bar"`.  I added a test to verify this—not sure if that's desirable, or even in the right spot.

This change removes the prefix at the `Element` level, and leaves its addition at the `Display` level, causing it to be rendered correctly.

Thanks!