### PR TITLE
fix typo error in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.1] - 2018-22-29
+## [0.1.1] - 2018-11-29
 
 ### Added
 


### PR DESCRIPTION
The month in the release date of version 0.1.1 is wrong. According to the code commit record, the correct month should be November.