### PR TITLE
add unsafe_text

### DIFF
--- a/typed-html/src/output/stdweb.rs
+++ b/typed-html/src/output/stdweb.rs
@@ -184,6 +184,7 @@ impl Stdweb {
     ) -> Result<web::Node, web::error::InvalidCharacterError> {
         match vnode {
             VNode::Text(text) => Ok(document.create_text_node(&text).into()),
+            VNode::UnsafeText(text) => Ok(document.create_text_node(&text).into()),
             VNode::Element(element) => {
                 let mut node = document.create_element(element.name)?;
                 for (key, value) in element.attributes {


### PR DESCRIPTION
Hi! Thanks for your work on `typed-html`, it's great.
I ran into the same issue as https://github.com/bodil/typed-html/issues/34.
I basically copied the code around `Text` and removed the bit that does escaping when rendering to a string. If there's a simpler way or a different approach you would prefer here, let me know.
Thanks!