### PR TITLE
Make Events struct more generic, use standard From/Into traits

### DIFF
--- a/macros/src/html.rs
+++ b/macros/src/html.rs
@@ -262,7 +262,7 @@ impl Element {
             let key = TokenTree::Ident(key.clone());
             let value = process_value(value);
             body.extend(quote!(
-                element.events.#key = Some(typed_html::events::IntoEventHandler::into_event_handler(#value));
+                element.events.#key = Some(#value.into());
             ));
         }
 

--- a/typed-html/src/events.rs
+++ b/typed-html/src/events.rs
@@ -3,6 +3,7 @@
 use crate::OutputType;
 use htmlescape::encode_attribute;
 use std::fmt::{Display, Error, Formatter};
+use std::iter;
 
 /// Trait for event handlers.
 pub trait EventHandler<T: OutputType, E> {
@@ -35,6 +36,18 @@ macro_rules! declare_events_struct {
             $(
                 pub $name: Option<T>,
             )*
+        }
+
+        impl<T> Events<T> {
+            pub fn iter(&self) -> impl Iterator<Item = (&'static str, &T)> {
+                iter::empty()
+                $(
+                    .chain(
+                        self.$name.iter()
+                        .map(|value| (stringify!($name), value))
+                    )
+                )*
+            }
         }
 
         impl<T> Default for Events<T> {

--- a/typed-html/src/events.rs
+++ b/typed-html/src/events.rs
@@ -42,6 +42,16 @@ macro_rules! declare_events_struct {
                     )
                 )*
             }
+
+            pub fn iter_mut(&mut self) -> impl Iterator<Item = (&'static str, &mut T)> {
+                iter::empty()
+                $(
+                    .chain(
+                        self.$name.iter_mut()
+                        .map(|value| (stringify!($name), value))
+                    )
+                )*
+            }
         }
 
         impl<T> Default for Events<T> {

--- a/typed-html/src/events.rs
+++ b/typed-html/src/events.rs
@@ -161,3 +161,52 @@ declare_events_struct! {
     volumechange,
     waiting,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_events_iter() {
+        let events: Events<&str> = Events::default();
+
+        let mut iter = events.iter();
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_events_iter() {
+        let mut events: Events<&str> = Events::default();
+        events.abort = Some("abort");
+        events.waiting = Some("waiting");
+
+        let mut iter = events.iter();
+        assert_eq!(iter.next(), Some(("abort", &"abort")));
+        assert_eq!(iter.next(), Some(("waiting", &"waiting")));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_events_iter_mut() {
+        let mut events: Events<&str> = Events::default();
+        events.abort = Some("abort");
+        events.waiting = Some("waiting");
+
+        let mut iter = events.iter_mut();
+        assert_eq!(iter.next(), Some(("abort", &mut "abort")));
+        assert_eq!(iter.next(), Some(("waiting", &mut "waiting")));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_events_into_iter() {
+        let mut events: Events<&str> = Events::default();
+        events.abort = Some("abort");
+        events.waiting = Some("waiting");
+
+        let mut iter = events.into_iter();
+        assert_eq!(iter.next(), Some(("abort", "abort")));
+        assert_eq!(iter.next(), Some(("waiting", "waiting")));
+        assert_eq!(iter.next(), None);
+    }
+}

--- a/typed-html/src/events.rs
+++ b/typed-html/src/events.rs
@@ -54,6 +54,24 @@ macro_rules! declare_events_struct {
             }
         }
 
+        impl<T: 'static> IntoIterator for Events<T> {
+            type Item = (&'static str, T);
+            type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
+
+            fn into_iter(mut self) -> Self::IntoIter {
+                Box::new(
+                    iter::empty()
+                    $(
+                        .chain(
+                            iter::once(self.$name.take())
+                            .filter(|value| value.is_some())
+                            .map(|value| (stringify!($name), value.unwrap()))
+                        )
+                    )*
+                )
+            }
+        }
+
         impl<T> Default for Events<T> {
             fn default() -> Self {
                 Events {

--- a/typed-html/src/events.rs
+++ b/typed-html/src/events.rs
@@ -24,12 +24,6 @@ pub trait EventHandler<T: OutputType, E> {
     fn render(&self) -> Option<String>;
 }
 
-/// Trait for building event handlers from other types.
-pub trait IntoEventHandler<T: OutputType, E> {
-    /// Construct an event handler from an instance of the source type.
-    fn into_event_handler(self) -> Box<dyn EventHandler<T, E>>;
-}
-
 macro_rules! declare_events_struct {
     ($($name:ident,)*) => {
         pub struct Events<T> {

--- a/typed-html/src/lib.rs
+++ b/typed-html/src/lib.rs
@@ -221,7 +221,7 @@ pub trait OutputType {
 
 /// String output
 impl OutputType for String {
-    type Events = events::StringEvents;
+    type Events = events::Events<String>;
     type EventTarget = ();
     type EventListenerHandle = ();
 }

--- a/typed-html/src/lib.rs
+++ b/typed-html/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "128"]
 //! This crate provides the `html!` macro for building HTML documents inside your
 //! Rust code using roughly [JSX] compatible syntax.
 //!

--- a/typed-html/src/output/stdweb.rs
+++ b/typed-html/src/output/stdweb.rs
@@ -6,7 +6,7 @@ use stdweb::web::{self, Element, EventListenerHandle, IElement, IEventTarget, IN
 
 use crate::OutputType;
 use crate::dom::VNode;
-use crate::events::{EventHandler, IntoEventHandler};
+use crate::events::EventHandler;
 
 /// DOM output using the stdweb crate
 pub struct Stdweb;
@@ -136,23 +136,13 @@ where
     }
 }
 
-impl<F, E> IntoEventHandler<Stdweb, E> for F
+impl<F, E> From<F> for Box<dyn EventHandler<Stdweb, E>>
 where
     F: FnMut(E) + 'static,
     E: ConcreteEvent + 'static,
 {
-    fn into_event_handler(self) -> Box<dyn EventHandler<Stdweb, E>> {
-        Box::new(EFn::new(self))
-    }
-}
-
-impl<F, E> IntoEventHandler<Stdweb, E> for EFn<F, E>
-where
-    F: FnMut(E) + 'static,
-    E: ConcreteEvent + 'static,
-{
-    fn into_event_handler(self) -> Box<dyn EventHandler<Stdweb, E>> {
-        Box::new(self)
+    fn from(f: F) -> Self {
+        Box::new(EFn::new(f))
     }
 }
 


### PR DESCRIPTION
In this PR I changed the code to make the event handling code more generic by allowing any type to be stored in the event, not just things implementing the `EventHandler` trait. I also converted the code to use the standard `Into`/`From` traits instead of the custom `IntoEventHandler` trait. I also added an way to iterate over ever event registered in a given `Events` struct.

These changes make the vdom functionality of this crate more flexible, because any type can be used as the event type. Previously, only the `EventHandler` trait could be used for the event type, and that trait doesn't offer access to the underlying type. Additionally, each custom event type required defining a custom `Events` struct with a very specific layout. Now the `Events` struct is generic and one only needs to specify the `OutputType` to use a custom event type (`OutputType` could also go away at this point, but I didn't make that change).