### PR TITLE
Support expressions in text! macro

### DIFF
--- a/typed-html/src/dom.rs
+++ b/typed-html/src/dom.rs
@@ -139,7 +139,7 @@ macro_rules! text {
     ($t:expr) => {
         Box::new($crate::dom::TextNode::new($t))
     };
-    ($format:tt, $($tail:tt),*) => {
+    ($format:tt, $($tail:expr),*) => {
         Box::new($crate::dom::TextNode::new(format!($format, $($tail),*)))
     };
 }


### PR DESCRIPTION
Allows the use of `text!("something {} else", something.item)`