### PR TITLE
stdweb example: specify release and fix path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 **/*.rs.bk
 Cargo.lock
+**/package-lock.json
+**/wasm-pack.log

--- a/examples/stdweb/README.md
+++ b/examples/stdweb/README.md
@@ -6,7 +6,7 @@ Simple example of compiling app consuming typed-html to WebAssembly.
 
 Make sure you have `cargo-web` installed: [Instructions](https://github.com/koute/cargo-web/#installation)
 
-Build using `cargo web build`
+Build using `cargo web build --release`
 
 _Note: There may be an issue that can be worked around as described [here](https://github.com/bodil/typed-html/issues/6), due to a bug in stdweb_
 

--- a/examples/stdweb/www/index.html
+++ b/examples/stdweb/www/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>typed-html WASM example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="./typed-html-wasm-test.js"></script>
+  <script src="./typed-html-stdweb-test.js"></script>
 </head>
 <body>
 </body>


### PR DESCRIPTION
Make the stdweb example build