### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/typed-html/src/types/spacedlist.rs
+++ b/typed-html/src/types/spacedlist.rs
@@ -245,7 +245,7 @@ macro_rules! spacedlist_from_array {
         {
             type Error = <A as FromStr>::Err;
             fn try_from(s: [&str; $num]) -> Result<Self, Self::Error> {
-                s.into_iter().map(|s| FromStr::from_str(*s)).collect()
+                s.iter().map(|s| FromStr::from_str(*s)).collect()
             }
         }
     };

--- a/typed-html/src/types/spacedset.rs
+++ b/typed-html/src/types/spacedset.rs
@@ -272,7 +272,7 @@ macro_rules! spacedset_from_array {
         {
             type Error = <A as FromStr>::Err;
             fn try_from(s: [&str; $num]) -> Result<Self, Self::Error> {
-                s.into_iter().map(|s| FromStr::from_str(*s)).collect()
+                s.iter().map(|s| FromStr::from_str(*s)).collect()
             }
         }
     };


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.