### PR TITLE
Increase recursion limit

### DIFF
--- a/typed-html/src/lib.rs
+++ b/typed-html/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "128"]
+#![recursion_limit = "256"]
 //! This crate provides the `html!` macro for building HTML documents inside your
 //! Rust code using roughly [JSX] compatible syntax.
 //!


### PR DESCRIPTION
Changes[1] to the Rust standard library are affecting[2] the nesting
size of types to the point where typed-html can not be built on nightly.

This resolves the issue by increasing the acceptable recursion depth for
the crate.

[1]: https://github.com/rust-lang/rust/pull/70896
[2]: https://github.com/rust-lang/rust/issues/71359

Closes: https://github.com/bodil/typed-html/issues/112

---

Whether this is a cautionary does-no-harm change or an actual fix for an issue with newer version depends on how the underlying issue[2] is resolved on Rust side. Possibly it's considered acceptable breakage (given overrides to the recursion limits are easy to fix, inherently depend on Rust compiler internals, and that the default is good enough for most cases), and then this is the mitigation to be applied in this crate.